### PR TITLE
Add cpt project to projects page

### DIFF
--- a/projects.html
+++ b/projects.html
@@ -48,4 +48,27 @@ permalink: /projects/
             </div>
         </div>
     </div>
+
+    <div class="frost-card rounded-2xl p-6 lg:p-8 group">
+        <div class="flex flex-col md:flex-row items-center gap-6">
+            <div class="relative">
+                <div class="absolute -inset-1 bg-gradient-to-r from-sky-400 via-cyan-400 to-sky-400 rounded-full opacity-30 blur"></div>
+                <div class="relative w-24 h-24 rounded-full border-4 border-white shadow-lg bg-frost-900 flex items-center justify-center">
+                    <span class="text-3xl font-mono font-bold text-white">&gt;_</span>
+                </div>
+            </div>
+            <div class="flex-1 text-center md:text-left">
+                <h2 class="font-serif text-2xl text-frost-900 mb-3">cpt</h2>
+                <p class="text-frost-600 font-sans leading-relaxed mb-4">Add Copilot chat to any terminal. Press Ctrl+K to get AI-powered command suggestions right in your shell. Supports macOS, Linux, and Windows (WSL) across zsh, bash, fish, and PowerShell. Built with Go.</p>
+                <div class="flex flex-wrap gap-3 justify-center md:justify-start">
+                    <a href="https://burkeholland.github.io/cpt" class="inline-flex items-center px-4 py-2 text-sm font-medium text-sky-600 bg-sky-500/10 rounded-full hover:bg-sky-500/20 transition-colors" target="_blank">
+                        Visit cpt →
+                    </a>
+                    <a href="https://github.com/burkeholland/cpt" class="inline-flex items-center px-4 py-2 text-sm font-medium text-frost-600 bg-frost-100 rounded-full hover:bg-frost-200 transition-colors" target="_blank">
+                        GitHub →
+                    </a>
+                </div>
+            </div>
+        </div>
+    </div>
 </div>


### PR DESCRIPTION
Adds a project card for [cpt](https://burkeholland.github.io/cpt) — a tool that adds Copilot chat to any terminal via Ctrl+K. Includes links to the landing page and GitHub repo.